### PR TITLE
fix log level not applied when configured level is unknown

### DIFF
--- a/skills-client-js/src/SkillsService.js
+++ b/skills-client-js/src/SkillsService.js
@@ -45,11 +45,11 @@ export default {
         this.sendLogMessage(serviceUrl, messages, context);
       });
       let loggingLevel = log[response.clientLib.loggingLevel];
-      log.setLevel(loggingLevel);
       if (!loggingLevel) {
         loggingLevel = log.INFO;
         log.warn(`SkillsClient::SkillService::Unknown log level [${response.clientLib.loggingLevel}], defaulting to INFO`);
       }
+      log.setLevel(loggingLevel);
       log.info(`SkillsClient::SkillService::Logger enabled, log level set to [${loggingLevel.name}]`);
     }
   },

--- a/skills-client-js/test/SkillsService.test.js
+++ b/skills-client-js/test/SkillsService.test.js
@@ -153,12 +153,18 @@ describe('OAuth auto redirect tests', () => {
     const logWarnSpy = jest.spyOn(log, 'warn').mockImplementation();
     const consoleSpy = jest.spyOn(console, 'info').mockImplementation();
 
+    // start from a level other than INFO so we can tell the default was applied
+    log.setLevel(log.ERROR);
+
     SkillsService.configureLogging(mockServiceUrl, response);
 
     // Verify the specific warning message was logged
     expect(logWarnSpy).toHaveBeenCalledWith(
         'SkillsClient::SkillService::Unknown log level [UNKNOWN_LEVEL], defaulting to INFO'
     );
+
+    // the logger should actually be at INFO, not left at the previous level
+    expect(log.getLevel()).toBe(log.INFO);
 
     // Verify that logging still works after defaulting to INFO
     log.info('Test message after defaulting');


### PR DESCRIPTION
While reading through `SkillsService.configureLogging` I noticed the fallback to INFO doesn't actually take effect.

When the service status returns a `loggingLevel` that doesn't map to a js-logger level, `log[response.clientLib.loggingLevel]` is `undefined`. The code calls `log.setLevel(loggingLevel)` first and only then defaults `loggingLevel` to `log.INFO`, so the second value is never handed to `setLevel`. js-logger treats `setLevel(undefined)` as a no-op, which leaves the logger at whatever level it was on before. So it warns "defaulting to INFO" but the logger is not actually at INFO.

The fix just moves the `setLevel` call below the fallback block so the resolved level (the real one, or INFO) is the one that gets applied.

There was already a test for the unknown-level case, but it only checked that the warning fired. I set the logger to a different level up front and added an assertion that `log.getLevel()` is INFO after the call. It fails on master (stays at the previous level) and passes with the change.

Ran `npx jest` for the whole js package, all 91 tests pass, and `eslint src/**` is clean.