### PR TITLE
Encode the redirect target before interpolating it into the authenticator URL

### DIFF
--- a/skills-client-js/src/SkillsService.js
+++ b/skills-client-js/src/SkillsService.js
@@ -119,7 +119,7 @@ export default {
           if (xhr.status !== 200) {
             if (isOAuthMode && oauthRedirect && xhr.status === 401) {
               // if we get 401 and we are using OAuth, then redirect to the OAuth Provider
-              const oauthAuthenticator = `${authenticator}?skillsRedirectUri=${window.location}`;
+              const oauthAuthenticator = `${authenticator}?skillsRedirectUri=${encodeURIComponent(window.location.href)}`;
               log.info(`SkillsClient::SkillService::unable to get oAuth token, navigating to [${oauthAuthenticator}]`);
               this.assignWindowLocation(oauthAuthenticator);
               resolve();

--- a/skills-client-js/test/SkillsService.test.js
+++ b/skills-client-js/test/SkillsService.test.js
@@ -45,7 +45,23 @@ describe('OAuth auto redirect tests', () => {
     await SkillsService.getAuthenticationToken(authEndpoint, mockServiceUrl, mockProjectId, true);
 
     expect(SkillsService.assignWindowLocation).toHaveBeenCalledTimes(1)
-    expect(SkillsService.assignWindowLocation).toHaveBeenCalledWith(`${authEndpoint}?skillsRedirectUri=http://localhost/`)
+    expect(SkillsService.assignWindowLocation).toHaveBeenCalledWith(`${authEndpoint}?skillsRedirectUri=${encodeURIComponent('http://localhost/')}`)
+  });
+
+  it('oauth redirect encodes the current location so it cannot add query parameters', async () => {
+    const oauthTokenEndpoint = `${mockServiceUrl}/api/projects/${mockProjectId}/token`;
+    mock.get(oauthTokenEndpoint, (req, res) => res.status(401));
+
+    window.history.pushState({}, '', '/page?a=1&skillsRedirectUri=http://evil.example.com/');
+    const injected = window.location.href;
+
+    await SkillsService.getAuthenticationToken(authEndpoint, mockServiceUrl, mockProjectId, true);
+
+    const [redirectedTo] = SkillsService.assignWindowLocation.mock.calls[0];
+    expect(redirectedTo).toBe(`${authEndpoint}?skillsRedirectUri=${encodeURIComponent(injected)}`);
+    // the injected separators must not survive as separators
+    expect(redirectedTo.split('?')).toHaveLength(2);
+    expect(redirectedTo).not.toContain('&skillsRedirectUri=');
   });
 
   it('oauth does not auto redirect when oauthRedirect=false', async () => {


### PR DESCRIPTION
Closes #284.

`getAuthenticationToken()` built the OAuth redirect like this:

```js
const oauthAuthenticator = `${authenticator}?skillsRedirectUri=${window.location}`;
```

`window.location` stringifies to the full current URL, so any reserved character already in that URL was carried into the authenticator URL as structure rather than as data. If the page was reached with an ampersand in its own query string, everything after it became additional parameters on the authenticator URL, including a second `skillsRedirectUri`.

This wraps the value in `encodeURIComponent` and reads `.href` explicitly rather than relying on implicit stringification.

On the tests: the existing `oauth auto redirects when oauthRedirect=true` case asserted the raw unencoded URL, so it is updated to expect the encoded form. The new case drives the interesting input, a location whose query string already carries `&skillsRedirectUri=...`, and asserts both that the whole thing arrives encoded and that the injected separators did not survive as separators.

Reverting the `SkillsService.js` change fails both, with the injected parameter coming through intact:

```
Expected: "...?skillsRedirectUri=http%3A%2F%2Flocalhost%2Fpage%3Fa%3D1%26skillsRedirectUri%3Dhttp%3A%2F%2Fevil.example.com%2F"
Received: "...?skillsRedirectUri=http://localhost/page?a=1&skillsRedirectUri=http://evil.example.com/"
```

The full `skills-client-js` suite passes with the change in, 92 tests across 12 suites.